### PR TITLE
Enable mobile fullscreen including portrait

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,46 +1,62 @@
-<style>
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-    border: 0;
-    font: inherit;
-    vertical-align: baseline;
-  }
-  body {
-    background: black;
-    margin: 0;
-  }
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+        border: 0;
+        font: inherit;
+        vertical-align: baseline;
+      }
 
-  canvas {
-    width: 1024px;
-    height: 576px;
-  }
-</style>
-<canvas style="image-rendering: pixelated"></canvas>
-<p style="color: white; font-family: sans-serif; margin: 8px">
-  WASD to move, Spacebar to roll / attack
-</p>
-<script src="./data/l_New_Layer_1.js"></script>
-<script src="./data/l_New_Layer_2.js"></script>
-<script src="./data/l_New_Layer_8.js"></script>
-<script src="./data/l_Back_Tiles.js"></script>
-<script src="./data/l_Decorations.js"></script>
-<script src="./data/l_Front_Tiles.js"></script>
-<script src="./data/l_Shrooms.js"></script>
-<script src="./data/l_Collisions.js"></script>
-<script src="./data/l_Grass.js"></script>
-<script src="./data/l_Trees.js"></script>
-<script src="./data/l_Gems.js"></script>
-<script src="./data/collisions.js"></script>
-<script src="./js/utils.js"></script>
-<script src="./classes/CollisionBlock.js"></script>
-<script src="./classes/Platform.js"></script>
-<script src="./classes/Player.js"></script>
-<script src="./classes/Oposum.js"></script>
-<script src="./classes/Eagle.js"></script>
-<script src="./classes/Sprite.js"></script>
-<script src="./classes/Heart.js"></script>
+      html,
+      body {
+        height: 100%;
+        background: black;
+        overflow: hidden;
+      }
 
-<script src="./js/index.js"></script>
-<script src="./js/eventListeners.js"></script>
+      canvas {
+        display: block;
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas style="image-rendering: pixelated"></canvas>
+    <p style="color: white; font-family: sans-serif; margin: 8px">
+      WASD to move, Spacebar to roll / attack
+    </p>
+    <script src="./data/l_New_Layer_1.js"></script>
+    <script src="./data/l_New_Layer_2.js"></script>
+    <script src="./data/l_New_Layer_8.js"></script>
+    <script src="./data/l_Back_Tiles.js"></script>
+    <script src="./data/l_Decorations.js"></script>
+    <script src="./data/l_Front_Tiles.js"></script>
+    <script src="./data/l_Shrooms.js"></script>
+    <script src="./data/l_Collisions.js"></script>
+    <script src="./data/l_Grass.js"></script>
+    <script src="./data/l_Trees.js"></script>
+    <script src="./data/l_Gems.js"></script>
+    <script src="./data/collisions.js"></script>
+    <script src="./js/utils.js"></script>
+    <script src="./classes/CollisionBlock.js"></script>
+    <script src="./classes/Platform.js"></script>
+    <script src="./classes/Player.js"></script>
+    <script src="./classes/Oposum.js"></script>
+    <script src="./classes/Eagle.js"></script>
+    <script src="./classes/Sprite.js"></script>
+    <script src="./classes/Heart.js"></script>
+
+    <script src="./js/index.js"></script>
+    <script src="./js/eventListeners.js"></script>
+  </body>
+</html>

--- a/js/index.js
+++ b/js/index.js
@@ -1,9 +1,14 @@
 const canvas = document.querySelector('canvas')
 const c = canvas.getContext('2d')
-const dpr = 2
+const dpr = window.devicePixelRatio || 1
 
-canvas.width = 1024 * dpr
-canvas.height = 576 * dpr
+function resizeCanvas() {
+  canvas.width = window.innerWidth * dpr
+  canvas.height = window.innerHeight * dpr
+}
+
+resizeCanvas()
+window.addEventListener('resize', resizeCanvas)
 
 const oceanLayerData = {
   l_New_Layer_1: l_New_Layer_1,


### PR DESCRIPTION
## Summary
- Add responsive viewport meta tag and canvas styles for full-screen mobile display
- Resize canvas to device dimensions and update on orientation changes

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a85ae2a1d0832a89a7bb7d02abbc82