### PR TITLE
Add touch controls with virtual joystick and action button

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,13 +28,55 @@
         width: 100vw;
         height: 100vh;
       }
+
+      /* Touch controls */
+      #joystick-base {
+        position: absolute;
+        bottom: 20px;
+        left: 20px;
+        width: 100px;
+        height: 100px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.1);
+        touch-action: none;
+      }
+
+      #joystick-knob {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 40px;
+        height: 40px;
+        margin-left: -20px;
+        margin-top: -20px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.3);
+        pointer-events: none;
+        transition: transform 0.2s ease;
+      }
+
+      #action-button {
+        position: absolute;
+        bottom: 20px;
+        right: 20px;
+        width: 60px;
+        height: 60px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.3);
+        touch-action: none;
+      }
     </style>
   </head>
   <body>
     <canvas style="image-rendering: pixelated"></canvas>
     <p style="color: white; font-family: sans-serif; margin: 8px">
-      WASD to move, Spacebar to roll / attack
+      WASD to move, Spacebar to roll / attack. Drag left circle or tap right
+      button on touch devices.
     </p>
+    <div id="joystick-base">
+      <div id="joystick-knob"></div>
+    </div>
+    <div id="action-button"></div>
     <script src="./data/l_New_Layer_1.js"></script>
     <script src="./data/l_New_Layer_2.js"></script>
     <script src="./data/l_New_Layer_8.js"></script>

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -33,3 +33,66 @@ document.addEventListener('visibilitychange', () => {
     lastTime = performance.now()
   }
 })
+
+// Touch controls
+const joystickBase = document.getElementById('joystick-base')
+const joystickKnob = document.getElementById('joystick-knob')
+const actionButton = document.getElementById('action-button')
+
+let joystickPointerId = null
+let startX = 0
+let startY = 0
+const JOYSTICK_RADIUS = 50
+
+if (joystickBase && joystickKnob) {
+  joystickBase.addEventListener('pointerdown', (e) => {
+    joystickPointerId = e.pointerId
+    startX = e.clientX
+    startY = e.clientY
+    joystickKnob.style.transition = '0s'
+  })
+
+  joystickBase.addEventListener('pointermove', (e) => {
+    if (e.pointerId !== joystickPointerId) return
+
+    const dx = e.clientX - startX
+    const dy = e.clientY - startY
+    const clampedX = Math.max(-JOYSTICK_RADIUS, Math.min(JOYSTICK_RADIUS, dx))
+    const clampedY = Math.max(-JOYSTICK_RADIUS, Math.min(JOYSTICK_RADIUS, dy))
+    joystickKnob.style.transform = `translate(${clampedX}px, ${clampedY}px)`
+
+    const normalizedX = clampedX / JOYSTICK_RADIUS
+    const normalizedY = clampedY / JOYSTICK_RADIUS
+
+    keys.a.pressed = normalizedX < -0.3
+    keys.d.pressed = normalizedX > 0.3
+
+    if (normalizedY < -0.5 && !keys.w.pressed) {
+      player.jump()
+      keys.w.pressed = true
+    }
+  })
+
+  const endJoystick = () => {
+    joystickPointerId = null
+    joystickKnob.style.transition = '0.2s'
+    joystickKnob.style.transform = 'translate(0px, 0px)'
+    keys.a.pressed = false
+    keys.d.pressed = false
+    keys.w.pressed = false
+  }
+
+  joystickBase.addEventListener('pointerup', (e) => {
+    if (e.pointerId === joystickPointerId) endJoystick()
+  })
+
+  joystickBase.addEventListener('pointercancel', (e) => {
+    if (e.pointerId === joystickPointerId) endJoystick()
+  })
+}
+
+if (actionButton) {
+  actionButton.addEventListener('pointerdown', () => {
+    player.roll()
+  })
+}


### PR DESCRIPTION
## Summary
- Add on-screen joystick and action button for touch devices
- Handle pointer events to control movement, jumping, and rolling

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a85c4bad5c832a925517daaf399dbc