### PR TITLE
Center player, disable pinch zoom, add fullscreen control

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
         height: 100%;
         background: black;
         overflow: hidden;
+        touch-action: none;
       }
 
       canvas {
@@ -65,6 +66,19 @@
         background: rgba(255, 255, 255, 0.3);
         touch-action: none;
       }
+
+      #fullscreen-button {
+        position: absolute;
+        top: 20px;
+        right: 20px;
+        width: 40px;
+        height: 40px;
+        border-radius: 5px;
+        background: rgba(255, 255, 255, 0.3);
+        color: white;
+        font-family: sans-serif;
+        touch-action: none;
+      }
     </style>
   </head>
   <body>
@@ -77,6 +91,7 @@
       <div id="joystick-knob"></div>
     </div>
     <div id="action-button"></div>
+    <button id="fullscreen-button">⛶</button>
     <script src="./data/l_New_Layer_1.js"></script>
     <script src="./data/l_New_Layer_2.js"></script>
     <script src="./data/l_New_Layer_8.js"></script>

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -96,3 +96,28 @@ if (actionButton) {
     player.roll()
   })
 }
+
+const fullscreenButton = document.getElementById('fullscreen-button')
+if (fullscreenButton) {
+  fullscreenButton.addEventListener('click', () => {
+    const elem = document.documentElement
+    if (elem.requestFullscreen) {
+      elem.requestFullscreen()
+    } else if (elem.webkitRequestFullscreen) {
+      elem.webkitRequestFullscreen()
+    } else if (elem.msRequestFullscreen) {
+      elem.msRequestFullscreen()
+    }
+  })
+}
+
+document.addEventListener(
+  'touchmove',
+  (e) => {
+    e.preventDefault()
+  },
+  { passive: false },
+)
+document.addEventListener('gesturestart', (e) => e.preventDefault())
+document.addEventListener('gesturechange', (e) => e.preventDefault())
+document.addEventListener('gestureend', (e) => e.preventDefault())

--- a/js/index.js
+++ b/js/index.js
@@ -199,9 +199,6 @@ let camera = {
   y: 0,
 }
 
-const SCROLL_POST_RIGHT = 330
-const SCROLL_POST_TOP = 100
-const SCROLL_POST_BOTTOM = 220
 let oceanBackgroundCanvas = null
 let brambleBackgroundCanvas = null
 let gems = []
@@ -534,26 +531,20 @@ function animate(backgroundCanvas) {
     }
   }
 
-  // Track scroll post distance
-  if (player.x > SCROLL_POST_RIGHT && player.x < 1680) {
-    const scrollPostDistance = player.x - SCROLL_POST_RIGHT
-    camera.x = scrollPostDistance
-  }
-
-  if (player.y < SCROLL_POST_TOP && camera.y > 0) {
-    const scrollPostDistance = SCROLL_POST_TOP - player.y
-    camera.y = scrollPostDistance
-  }
-
-  if (player.y > SCROLL_POST_BOTTOM) {
-    const scrollPostDistance = player.y - SCROLL_POST_BOTTOM
-    camera.y = -scrollPostDistance
-  }
+  // Center camera on player
+  camera.x = Math.max(
+    0,
+    player.x - canvas.width / (2 * (dpr + 1))
+  )
+  camera.y = Math.max(
+    0,
+    player.y - canvas.height / (2 * (dpr + 1))
+  )
 
   // Render scene
   c.save()
   c.scale(dpr + 1, dpr + 1)
-  c.translate(-camera.x, camera.y)
+  c.translate(-camera.x, -camera.y)
   c.clearRect(0, 0, canvas.width, canvas.height)
   c.drawImage(oceanBackgroundCanvas, camera.x * 0.32, 0)
   c.drawImage(brambleBackgroundCanvas, camera.x * 0.16, 0)
@@ -580,9 +571,6 @@ function animate(backgroundCanvas) {
     gem.draw(c)
   }
 
-  // c.fillRect(SCROLL_POST_RIGHT, 100, 10, 100)
-  // c.fillRect(300, SCROLL_POST_TOP, 100, 10)
-  // c.fillRect(300, SCROLL_POST_BOTTOM, 100, 10)
   c.restore()
 
   // UI save and restore


### PR DESCRIPTION
## Summary
- Ensure camera centers on the player at all times
- Prevent page zooming and scrolling during touch interactions
- Add a fullscreen toggle button with cross-browser support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85dae49d4832a9fa2911a6f36d899