### PR TITLE
Disable double-tap zoom and adjust mobile controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,20 @@
         transition: transform 0.2s ease;
       }
 
-      #action-button {
+      #roll-button {
         position: absolute;
         bottom: 20px;
+        right: 20px;
+        width: 60px;
+        height: 60px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.3);
+        touch-action: none;
+      }
+
+      #jump-button {
+        position: absolute;
+        bottom: 100px;
         right: 20px;
         width: 60px;
         height: 60px;
@@ -84,13 +95,14 @@
   <body>
     <canvas style="image-rendering: pixelated"></canvas>
     <p style="color: white; font-family: sans-serif; margin: 8px">
-      WASD to move, Spacebar to roll / attack. Drag left circle or tap right
-      button on touch devices.
+      WASD to move, Spacebar to roll / attack. Drag left circle to move and use
+      right buttons on touch devices.
     </p>
     <div id="joystick-base">
       <div id="joystick-knob"></div>
     </div>
-    <div id="action-button"></div>
+    <div id="roll-button"></div>
+    <div id="jump-button"></div>
     <button id="fullscreen-button">⛶</button>
     <script src="./data/l_New_Layer_1.js"></script>
     <script src="./data/l_New_Layer_2.js"></script>

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -2,7 +2,6 @@ window.addEventListener('keydown', (event) => {
   switch (event.key) {
     case 'w':
       player.jump()
-      keys.w.pressed = true
       break
     case 'a':
       keys.a.pressed = true
@@ -37,7 +36,8 @@ document.addEventListener('visibilitychange', () => {
 // Touch controls
 const joystickBase = document.getElementById('joystick-base')
 const joystickKnob = document.getElementById('joystick-knob')
-const actionButton = document.getElementById('action-button')
+const rollButton = document.getElementById('roll-button')
+const jumpButton = document.getElementById('jump-button')
 
 let joystickPointerId = null
 let startX = 0
@@ -62,15 +62,9 @@ if (joystickBase && joystickKnob) {
     joystickKnob.style.transform = `translate(${clampedX}px, ${clampedY}px)`
 
     const normalizedX = clampedX / JOYSTICK_RADIUS
-    const normalizedY = clampedY / JOYSTICK_RADIUS
 
     keys.a.pressed = normalizedX < -0.3
     keys.d.pressed = normalizedX > 0.3
-
-    if (normalizedY < -0.5 && !keys.w.pressed) {
-      player.jump()
-      keys.w.pressed = true
-    }
   })
 
   const endJoystick = () => {
@@ -79,7 +73,6 @@ if (joystickBase && joystickKnob) {
     joystickKnob.style.transform = 'translate(0px, 0px)'
     keys.a.pressed = false
     keys.d.pressed = false
-    keys.w.pressed = false
   }
 
   joystickBase.addEventListener('pointerup', (e) => {
@@ -91,9 +84,15 @@ if (joystickBase && joystickKnob) {
   })
 }
 
-if (actionButton) {
-  actionButton.addEventListener('pointerdown', () => {
+if (rollButton) {
+  rollButton.addEventListener('pointerdown', () => {
     player.roll()
+  })
+}
+
+if (jumpButton) {
+  jumpButton.addEventListener('pointerdown', () => {
+    player.jump()
   })
 }
 
@@ -121,3 +120,18 @@ document.addEventListener(
 document.addEventListener('gesturestart', (e) => e.preventDefault())
 document.addEventListener('gesturechange', (e) => e.preventDefault())
 document.addEventListener('gestureend', (e) => e.preventDefault())
+
+let lastTouchEnd = 0
+document.addEventListener(
+  'touchend',
+  (e) => {
+    const now = new Date().getTime()
+    if (now - lastTouchEnd <= 300) {
+      e.preventDefault()
+    }
+    lastTouchEnd = now
+  },
+  { passive: false },
+)
+
+document.addEventListener('dblclick', (e) => e.preventDefault())

--- a/js/index.js
+++ b/js/index.js
@@ -182,9 +182,6 @@ let hearts = [
 ]
 
 const keys = {
-  w: {
-    pressed: false,
-  },
   a: {
     pressed: false,
   },


### PR DESCRIPTION
## Summary
- Prevent double-tap zooming on touch devices.
- Restrict joystick to horizontal movement and add dedicated Roll and Jump buttons.
- Remove unused `w` key tracking.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85f04f898832abe53cb84eeef9db2