### PR TITLE
Restrict jumping to grounded state

### DIFF
--- a/classes/Player.js
+++ b/classes/Player.js
@@ -213,6 +213,7 @@ class Player {
   }
 
   jump() {
+    if (!this.isOnGround) return
     this.velocity.y = -JUMP_POWER
     this.isOnGround = false
   }


### PR DESCRIPTION
## Summary
- prevent jumping when not on the ground so double jumps are not possible

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a8616a78e4832a8eb5c29cf7f96030