### PR TITLE
Add browser-based level editor

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Level Editor</title>
+  <style>
+    body { background: #222; color: #fff; font-family: sans-serif; }
+    #toolbar { margin-bottom: 8px; }
+    button { margin-right: 4px; }
+    canvas { background: #333; image-rendering: pixelated; }
+    #output { width: 100%; height: 100px; margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <div id="toolbar">
+    <button data-tool="floor">Floor</button>
+    <button data-tool="enemy">Enemy</button>
+    <button data-tool="gem">Gem</button>
+    <button data-tool="erase">Erase</button>
+    <button id="save">Save</button>
+  </div>
+  <canvas id="editor" width="640" height="480"></canvas>
+  <textarea id="output" placeholder="Saved level data will appear here"></textarea>
+  <script src="js/editor.js"></script>
+</body>
+</html>

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,0 +1,96 @@
+const canvas = document.getElementById('editor');
+const ctx = canvas.getContext('2d');
+
+const tileSize = 32;
+const gridWidth = canvas.width / tileSize;
+const gridHeight = canvas.height / tileSize;
+
+const floors = Array.from({ length: gridHeight }, () => Array(gridWidth).fill(0));
+let enemies = [];
+let gems = [];
+let currentTool = 'floor';
+
+function drawGrid() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  for (let y = 0; y < gridHeight; y++) {
+    for (let x = 0; x < gridWidth; x++) {
+      if (floors[y][x]) {
+        ctx.fillStyle = '#555';
+        ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      }
+      ctx.strokeStyle = '#444';
+      ctx.strokeRect(x * tileSize, y * tileSize, tileSize, tileSize);
+    }
+  }
+
+  ctx.fillStyle = 'red';
+  enemies.forEach((e) => {
+    ctx.fillRect(e.x * tileSize + 8, e.y * tileSize + 8, tileSize - 16, tileSize - 16);
+  });
+
+  ctx.fillStyle = 'cyan';
+  gems.forEach((g) => {
+    ctx.beginPath();
+    ctx.arc(g.x * tileSize + tileSize / 2, g.y * tileSize + tileSize / 2, tileSize / 4, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+drawGrid();
+
+function getPos(evt) {
+  const rect = canvas.getBoundingClientRect();
+  const x = Math.floor((evt.clientX - rect.left) / tileSize);
+  const y = Math.floor((evt.clientY - rect.top) / tileSize);
+  return { x, y };
+}
+
+let drawing = false;
+canvas.addEventListener('mousedown', (e) => {
+  drawing = true;
+  handle(e);
+});
+canvas.addEventListener('mousemove', (e) => {
+  if (drawing) handle(e);
+});
+window.addEventListener('mouseup', () => {
+  drawing = false;
+});
+
+function handle(evt) {
+  const { x, y } = getPos(evt);
+  if (x < 0 || y < 0 || x >= gridWidth || y >= gridHeight) return;
+
+  if (currentTool === 'floor') {
+    floors[y][x] = 1;
+  } else if (currentTool === 'enemy') {
+    if (!enemies.some((e) => e.x === x && e.y === y)) enemies.push({ x, y });
+  } else if (currentTool === 'gem') {
+    if (!gems.some((g) => g.x === x && g.y === y)) gems.push({ x, y });
+  } else if (currentTool === 'erase') {
+    floors[y][x] = 0;
+    enemies = enemies.filter((e) => !(e.x === x && e.y === y));
+    gems = gems.filter((g) => !(g.x === x && g.y === y));
+  }
+
+  drawGrid();
+}
+
+document.getElementById('toolbar').addEventListener('click', (e) => {
+  const tool = e.target.dataset.tool;
+  if (tool) currentTool = tool;
+});
+
+document.getElementById('save').addEventListener('click', () => {
+  const data = JSON.stringify({ floors, enemies, gems }, null, 2);
+  document.getElementById('output').value = data;
+
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'map.json';
+  a.click();
+  URL.revokeObjectURL(url);
+});


### PR DESCRIPTION
## Summary
- add `editor.html` page with canvas and toolbar to place floor tiles, enemies, and gems
- implement `js/editor.js` for drawing grid, handling tools, and exporting JSON

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8738034b8832a965e630dbfb341e4