### PR TITLE
Save maps directly to data files

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -146,25 +146,25 @@ document.getElementById('toolbar').addEventListener('click', (e) => {
   if (tool) currentTool = tool;
 });
 
-document.getElementById('save').addEventListener('click', () => {
+document.getElementById('save').addEventListener('click', async () => {
   const gemGrid = Array.from({ length: gridHeight }, () =>
     Array(gridWidth).fill(0),
   );
   gems.forEach((g) => {
     gemGrid[g.y][g.x] = 18;
   });
-  const data =
-    `const collisions = ${JSON.stringify(floors)};\n` +
-    `const l_Gems = ${JSON.stringify(gemGrid)};`;
-  document.getElementById('output').value = data;
-
-  const blob = new Blob([data], { type: 'application/javascript' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'map.js';
-  a.click();
-  URL.revokeObjectURL(url);
+  try {
+    const res = await fetch('/save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ collisions: floors, gems: gemGrid }),
+    });
+    const text = await res.text();
+    document.getElementById('output').value = text;
+  } catch (err) {
+    console.error(err);
+    document.getElementById('output').value = 'Save failed';
+  }
   localStorage.setItem(
     'editorMap',
     JSON.stringify({ floors, enemies, gems }),

--- a/server.js
+++ b/server.js
@@ -1,0 +1,52 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const baseDir = __dirname;
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/save') {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const { collisions, gems } = JSON.parse(body);
+        fs.writeFileSync(
+          path.join(baseDir, 'data', 'collisions.js'),
+          `const collisions = ${JSON.stringify(collisions)};`
+        );
+        fs.writeFileSync(
+          path.join(baseDir, 'data', 'l_Gems.js'),
+          `const l_Gems = ${JSON.stringify(gems)};`
+        );
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('Saved');
+      } catch (err) {
+        console.error(err);
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Error saving');
+      }
+    });
+  } else {
+    const filePath = path.join(
+      baseDir,
+      req.url === '/' ? '/editor.html' : req.url
+    );
+    fs.readFile(filePath, (err, content) => {
+      if (err) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not found');
+      } else {
+        res.writeHead(200);
+        res.end(content);
+      }
+    });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Replace editor export with server-backed save that updates existing data files
- Add simple Node server to receive map data and write collisions/gems scripts

## Testing
- `node server.js & sleep 1; kill $!`
- `curl -X POST -H 'Content-Type: application/json' -d '{"collisions":[[1]],"gems":[[0]]}' http://localhost:3000/save`


------
https://chatgpt.com/codex/tasks/task_e_68a879c4ad64832ab35aa44b33807a95