### PR TITLE
Disable caching so saved levels load immediately

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,11 +21,17 @@ const server = http.createServer((req, res) => {
           path.join(baseDir, 'data', 'l_Gems.js'),
           `const l_Gems = ${JSON.stringify(gems)};`
         );
-        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.writeHead(200, {
+          'Content-Type': 'text/plain',
+          'Cache-Control': 'no-store',
+        });
         res.end('Saved');
       } catch (err) {
         console.error(err);
-        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.writeHead(500, {
+          'Content-Type': 'text/plain',
+          'Cache-Control': 'no-store',
+        });
         res.end('Error saving');
       }
     });
@@ -36,10 +42,13 @@ const server = http.createServer((req, res) => {
     );
     fs.readFile(filePath, (err, content) => {
       if (err) {
-        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.writeHead(404, {
+          'Content-Type': 'text/plain',
+          'Cache-Control': 'no-store',
+        });
         res.end('Not found');
       } else {
-        res.writeHead(200);
+        res.writeHead(200, { 'Cache-Control': 'no-store' });
         res.end(content);
       }
     });


### PR DESCRIPTION
## Summary
- prevent browser caching by sending `Cache-Control: no-store` on all responses

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68a87b2cd198832a963ac7054bced13c