### PR TITLE
Center editor toolbar and enable enemy type selection

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -8,8 +8,21 @@
   <title>Level Editor</title>
   <style>
     body { background: #222; color: #fff; font-family: sans-serif; }
-    #toolbar { margin-bottom: 8px; }
-    button { margin-right: 4px; }
+    #toolbar {
+      position: fixed;
+      bottom: 10px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      gap: 4px;
+      background: rgba(0, 0, 0, 0.5);
+      padding: 4px;
+      border-radius: 4px;
+      z-index: 1000;
+    }
+    #toolbar button {
+      margin: 0;
+    }
     canvas { background: #333; image-rendering: pixelated; }
     #output { width: 100%; height: 100px; margin-top: 8px; }
     #save-status { margin-top: 8px; font-weight: bold; }
@@ -18,7 +31,8 @@
 <body>
   <div id="toolbar">
     <button data-tool="floor">Floor</button>
-    <button data-tool="enemy">Enemy</button>
+    <button data-tool="enemy-oposum">Oposum</button>
+    <button data-tool="enemy-eagle">Eagle</button>
     <button data-tool="gem">Gem</button>
     <button data-tool="erase">Erase</button>
     <button id="save">Save</button>


### PR DESCRIPTION
## Summary
- Center editor toolbar at bottom and keep it fixed
- Add buttons for Oposum and Eagle enemy types
- Update editor script to handle multiple enemy images and types

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a8858d06cc832aa5a98a6ebddd020b