### PR TITLE
Align player to ground and improve editor mobile usability

### DIFF
--- a/classes/Player.js
+++ b/classes/Player.js
@@ -327,4 +327,19 @@ class Player {
     }
     this.isOnGround = false
   }
+
+  snapToGround(collisionBlocks) {
+    const tileSize = 16
+    const groundTileY = Math.floor((this.y + this.height) / tileSize)
+    const groundTileX = Math.floor((this.x + this.width / 2) / tileSize)
+    const block = collisionBlocks.find(
+      (b) => b.x === groundTileX * tileSize && b.y === groundTileY * tileSize,
+    )
+    if (block) {
+      this.y = block.y - this.height
+      this.hitbox.y = this.y + 9
+      this.velocity.y = 0
+      this.isOnGround = true
+    }
+  }
 }

--- a/editor.html
+++ b/editor.html
@@ -10,18 +10,20 @@
     body { background: #222; color: #fff; font-family: sans-serif; }
     #toolbar {
       position: fixed;
-      bottom: 10px;
+      top: 10px;
       left: 50%;
       transform: translateX(-50%);
       display: flex;
       gap: 4px;
       background: rgba(0, 0, 0, 0.5);
-      padding: 4px;
+      padding: 8px;
       border-radius: 4px;
       z-index: 1000;
     }
     #toolbar button {
       margin: 0;
+      padding: 8px 12px;
+      font-size: 16px;
     }
     canvas { background: #333; image-rendering: pixelated; }
     #output { width: 100%; height: 100px; margin-top: 8px; }

--- a/js/editor.js
+++ b/js/editor.js
@@ -108,8 +108,10 @@ function drawGrid() {
 
 function getPos(evt) {
   const rect = canvas.getBoundingClientRect();
-  const x = Math.floor((evt.clientX - rect.left) / tileSize);
-  const y = Math.floor((evt.clientY - rect.top) / tileSize);
+  const clientX = evt.touches ? evt.touches[0].clientX : evt.clientX;
+  const clientY = evt.touches ? evt.touches[0].clientY : evt.clientY;
+  const x = Math.floor((clientX - rect.left) / tileSize);
+  const y = Math.floor((clientY - rect.top) / tileSize);
   return { x, y };
 }
 
@@ -122,6 +124,19 @@ canvas.addEventListener('mousemove', (e) => {
   if (drawing) handle(e);
 });
 window.addEventListener('mouseup', () => {
+  drawing = false;
+});
+
+canvas.addEventListener('touchstart', (e) => {
+  e.preventDefault();
+  drawing = true;
+  handle(e);
+});
+canvas.addEventListener('touchmove', (e) => {
+  e.preventDefault();
+  if (drawing) handle(e);
+});
+window.addEventListener('touchend', () => {
   drawing = false;
 });
 

--- a/js/index.js
+++ b/js/index.js
@@ -169,6 +169,7 @@ let player = new Player({
   size: 32,
   velocity: { x: 0, y: 0 },
 })
+player.snapToGround(collisionBlocks)
 
 let oposums = []
 let eagles = []


### PR DESCRIPTION
## Summary
- snap player to nearest ground tile on load
- keep editor toolbar visible and touch-friendly
- enable touch dragging in level editor

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a886c757b4832aac9b67abfc1ffef7