### PR TITLE
Fix start and code buttons and restyle

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
+      rel="stylesheet"
+    />
     <style>
       * {
         box-sizing: border-box;
@@ -102,17 +106,26 @@
         height: 100%;
         background: url('./images/splashscreen.png') center/cover no-repeat;
         display: flex;
-        flex-direction: column;
         justify-content: center;
         align-items: center;
+        gap: 20px;
         z-index: 1000;
       }
 
       #start-screen button {
-        margin: 10px;
-        padding: 10px 20px;
-        font-family: sans-serif;
-        font-size: 1rem;
+        padding: 12px 24px;
+        font-family: 'Press Start 2P', cursive;
+        font-size: 0.8rem;
+        color: black;
+        background: #fff;
+        border: 4px solid black;
+        box-shadow: 4px 4px 0 black;
+        cursor: pointer;
+      }
+
+      #start-screen button:active {
+        box-shadow: 2px 2px 0 black;
+        transform: translate(2px, 2px);
       }
 
       #code-modal {

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -161,21 +161,21 @@ const codeButton = document.getElementById('code-button')
 const codeModal = document.getElementById('code-modal')
 const closeModalButton = document.getElementById('close-modal')
 
-if (startButton) {
-  startButton.addEventListener('click', () => {
-    if (startScreen) startScreen.style.display = 'none'
-    if (typeof startGame === 'function') startGame()
-  })
+const addPressListener = (element, handler) => {
+  if (!element) return
+  element.addEventListener('pointerdown', handler)
+  element.addEventListener('click', handler)
 }
 
-if (codeButton) {
-  codeButton.addEventListener('click', () => {
-    if (codeModal) codeModal.classList.remove('hidden')
-  })
-}
+addPressListener(startButton, () => {
+  if (startScreen) startScreen.style.display = 'none'
+  if (typeof startGame === 'function') startGame()
+})
 
-if (closeModalButton) {
-  closeModalButton.addEventListener('click', () => {
-    if (codeModal) codeModal.classList.add('hidden')
-  })
-}
+addPressListener(codeButton, () => {
+  if (codeModal) codeModal.classList.remove('hidden')
+})
+
+addPressListener(closeModalButton, () => {
+  if (codeModal) codeModal.classList.add('hidden')
+})


### PR DESCRIPTION
## Summary
- Ensure Start and Code buttons respond to pointer events and work on touch devices.
- Center Start and Code buttons side-by-side and apply retro pixel styling.

## Testing
- No tests were run.

------
https://chatgpt.com/codex/tasks/task_e_68a88ac4b62c832a8c3b5d38c946bea5