### PR TITLE
fix: make start screen buttons work on iOS Safari

### DIFF
--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -163,7 +163,18 @@ const closeModalButton = document.getElementById('close-modal')
 
 const addPressListener = (element, handler) => {
   if (!element) return
-  element.addEventListener('pointerdown', handler)
+
+  const onPress = (e) => {
+    e.preventDefault()
+    handler(e)
+  }
+
+  if (window.PointerEvent) {
+    element.addEventListener('pointerdown', onPress)
+  } else {
+    element.addEventListener('touchstart', onPress)
+  }
+
   element.addEventListener('click', handler)
 }
 


### PR DESCRIPTION
## Summary
- ensure start screen buttons respond on iOS by handling `touchstart`

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a88c313554832a9195cadd89897a20