### PR TITLE
chore: crop top pixel of player sprite

### DIFF
--- a/classes/Player.js
+++ b/classes/Player.js
@@ -114,16 +114,18 @@ class Player {
         c.globalAlpha = 1
       }
       c.scale(xScale, 1)
+      const cropTop = 1
+      const scaledCrop = Math.round(cropTop * this.scale)
       c.drawImage(
         this.image,
         this.currentSprite.x + this.currentSprite.width * this.currentFrame,
-        this.currentSprite.y,
+        this.currentSprite.y + cropTop,
         this.currentSprite.width,
-        this.currentSprite.height,
+        this.currentSprite.height - cropTop,
         drawX,
-        drawY,
+        drawY + scaledCrop,
         Math.round(this.width),
-        Math.round(this.height)
+        Math.round(this.height - scaledCrop)
       )
       c.restore()
     }


### PR DESCRIPTION
## Summary
- crop top pixel when drawing the player sprite to remove thin white line

## Testing
- no tests

------
https://chatgpt.com/codex/tasks/task_e_68ac55b49f78832aac026e0487cc5160