### PR TITLE
feat(floor): add floor atlas with autotyping and editor palette

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -28,6 +28,23 @@
     canvas { background: #333; image-rendering: pixelated; }
     #output { width: 100%; height: 100px; margin-top: 8px; }
     #save-status { margin-top: 8px; font-weight: bold; }
+    #palette {
+      position: fixed;
+      left: 10px;
+      top: 80px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      background: rgba(0, 0, 0, 0.5);
+      padding: 4px;
+    }
+    #palette canvas {
+      width: 32px;
+      height: 32px;
+      image-rendering: pixelated;
+      cursor: pointer;
+      border: 1px solid #444;
+    }
   </style>
 </head>
 <body>
@@ -44,6 +61,7 @@
     <button id="reset">Reset</button>
     <button id="extend">Extend Right</button>
   </div>
+  <div id="palette"></div>
   <canvas id="editor" width="640" height="480"></canvas>
   <div id="save-status"></div>
   <textarea id="output" placeholder="Saved level data will appear here"></textarea>
@@ -68,6 +86,7 @@
       '<script src="./data/l_Illusions.js?cb=' + cb + '"></' + 'script>'
     );
   </script>
+  <script src="js/floorTiles.js"></script>
   <script src="js/editor.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -241,6 +241,7 @@
     <script src="./classes/Sprite.js"></script>
     <script src="./classes/Heart.js"></script>
 
+    <script src="./js/floorTiles.js"></script>
     <script src="./js/index.js"></script>
     <script src="./js/eventListeners.js"></script>
   </body>

--- a/js/editor.js
+++ b/js/editor.js
@@ -15,7 +15,9 @@ let illusions;
 if (typeof collisions !== 'undefined') {
   gridHeight = collisions.length;
   gridWidth = collisions[0].length;
-  floors = collisions.map((row) => row.map((cell) => (cell ? 1 : 0)));
+  floors = collisions.map((row) =>
+    row.map((cell) => (cell ? 'solid_mass' : 'air')),
+  );
   blockers =
     typeof l_Blockers !== 'undefined' && l_Blockers.length
       ? l_Blockers
@@ -33,7 +35,9 @@ if (typeof collisions !== 'undefined') {
 } else {
   gridWidth = canvas.width / tileSize;
   gridHeight = canvas.height / tileSize;
-  floors = Array.from({ length: gridHeight }, () => Array(gridWidth).fill(0));
+  floors = Array.from({ length: gridHeight }, () =>
+    Array(gridWidth).fill('air'),
+  );
   blockers = Array.from({ length: gridHeight }, () =>
     Array(gridWidth).fill(0),
   );
@@ -65,7 +69,6 @@ if (typeof l_Enemies !== 'undefined') {
 const defaultState = JSON.parse(
   JSON.stringify({ floors, enemies, gems, blockers, deaths, illusions }),
 );
-let floorImg;
 const enemyImgs = {};
 let gemImg;
 
@@ -79,12 +82,11 @@ function loadImage(src) {
 }
 
 Promise.all([
-  loadImage('./images/tileset.png'),
+  loadImage('./images/floor.png'),
   loadImage('./images/oposum.png'),
   loadImage('./images/eagle.png'),
   loadImage('./images/gem.png'),
-]).then(([tile, oposum, eagle, gem]) => {
-  floorImg = tile;
+]).then(([_, oposum, eagle, gem]) => {
   enemyImgs.oposum = oposum;
   enemyImgs.eagle = eagle;
   gemImg = gem;
@@ -102,22 +104,63 @@ Promise.all([
     canvas.width = gridWidth * tileSize;
     canvas.height = gridHeight * tileSize;
   }
+  setupPalette();
   drawGrid();
 });
 let currentTool = 'floor';
+let currentFloorType = 'solid_mass';
+
+function setupPalette() {
+  const palette = document.getElementById('palette');
+  palette.innerHTML = '';
+  const mapping = {
+    grass_top: 'grass_mid',
+    solid_mass: 'mass_plain',
+    overhang: 'grass_overhang_mid',
+  };
+  FloorTiles.LOGICAL_TYPES.forEach((type) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 32;
+    canvas.height = 32;
+    const pctx = canvas.getContext('2d');
+    const tileName = mapping[type] || 'mass_plain';
+    const pos = FloorTiles.FLOOR_TILES[tileName];
+    pctx.imageSmoothingEnabled = false;
+    pctx.drawImage(
+      FloorTiles.floorAtlas,
+      (pos.c - 1) * FloorTiles.SRC_TILE,
+      (pos.r - 1) * FloorTiles.SRC_TILE,
+      FloorTiles.SRC_TILE,
+      FloorTiles.SRC_TILE,
+      0,
+      0,
+      32,
+      32,
+    );
+    canvas.addEventListener('click', () => {
+      currentTool = 'floor';
+      currentFloorType = type;
+    });
+    palette.appendChild(canvas);
+  });
+}
 
 function drawGrid() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
   for (let y = 0; y < gridHeight; y++) {
     for (let x = 0; x < gridWidth; x++) {
-      if (floors[y][x]) {
+      const name = FloorTiles.autotile(floors, x, y);
+      if (name) {
+        const pos = FloorTiles.FLOOR_TILES[name];
+        const sx = (pos.c - 1) * FloorTiles.SRC_TILE;
+        const sy = (pos.r - 1) * FloorTiles.SRC_TILE;
         ctx.drawImage(
-          floorImg,
-          0,
-          0,
-          16,
-          16,
+          FloorTiles.floorAtlas,
+          sx,
+          sy,
+          FloorTiles.SRC_TILE,
+          FloorTiles.SRC_TILE,
           x * tileSize,
           y * tileSize,
           tileSize,
@@ -196,7 +239,7 @@ function handle(evt) {
   if (x < 0 || y < 0 || x >= gridWidth || y >= gridHeight) return;
 
   if (currentTool === 'floor') {
-    floors[y][x] = 1;
+    floors[y][x] = currentFloorType;
   } else if (currentTool === 'blocker') {
     blockers[y][x] = 1;
   } else if (currentTool === 'death') {
@@ -209,7 +252,7 @@ function handle(evt) {
   } else if (currentTool === 'gem') {
     if (!gems.some((g) => g.x === x && g.y === y)) gems.push({ x, y });
   } else if (currentTool === 'erase') {
-    floors[y][x] = 0;
+    floors[y][x] = 'air';
     blockers[y][x] = 0;
     deaths[y][x] = 0;
     illusions[y][x] = 0;
@@ -244,7 +287,9 @@ document.getElementById('save').addEventListener('click', async () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        collisions: floors,
+        collisions: floors.map((row) =>
+          row.map((cell) => (cell === 'air' ? 0 : 1)),
+        ),
         gems: gemGrid,
         enemies: enemyGrid,
         blockers,
@@ -289,7 +334,7 @@ document.getElementById('reset').addEventListener('click', () => {
 document.getElementById('extend').addEventListener('click', () => {
   const cols = parseInt(prompt('Columns to add?', '10'), 10);
   if (!cols) return;
-  floors.forEach((row) => row.push(...Array(cols).fill(0)));
+  floors.forEach((row) => row.push(...Array(cols).fill('air')));
   blockers.forEach((row) => row.push(...Array(cols).fill(0)));
   deaths.forEach((row) => row.push(...Array(cols).fill(0)));
   illusions.forEach((row) => row.push(...Array(cols).fill(0)));

--- a/js/floorTiles.js
+++ b/js/floorTiles.js
@@ -1,0 +1,156 @@
+const SRC_TILE = 32;
+const DST_TILE = TILE_NATIVE;
+const SCALE = DST_TILE / SRC_TILE;
+
+const floorAtlas = new Image();
+floorAtlas.src = './images/floor.png';
+
+// Mapping table: logical tile name -> {col,row}
+// 1-based columns/rows
+const FLOOR_TILES = {
+  grass_left: { c: 1, r: 1 },
+  grass_mid: { c: 2, r: 1 },
+  grass_right: { c: 3, r: 1 },
+  grass_overhang_left: { c: 4, r: 1 },
+  grass_overhang_mid: { c: 5, r: 1 },
+  grass_overhang_right: { c: 6, r: 1 },
+  mass_corner_ur_hollow: { c: 7, r: 1 },
+  mass_bottom_hollow: { c: 8, r: 1 },
+  mass_corner_ul_hollow: { c: 9, r: 1 },
+
+  chasm_end_left: { c: 1, r: 2 },
+  mass_plain: { c: 2, r: 2 },
+  chasm_end_right: { c: 3, r: 2 },
+  chasm_mid_inset_right: { c: 4, r: 2 },
+  hole: { c: 5, r: 2 },
+  chasm_mid_inset_left: { c: 6, r: 2 },
+  mass_with_air_right: { c: 7, r: 2 },
+  air: { c: 8, r: 2 },
+  mass_with_air_left: { c: 9, r: 2 },
+
+  bottom_left: { c: 1, r: 3 },
+  bottom_mid: { c: 2, r: 3 },
+  bottom_right: { c: 3, r: 3 },
+  bottom_left_with_diag_up_right_hollow: { c: 4, r: 3 },
+  bottom_mid_with_up_hollow: { c: 5, r: 3 },
+  bottom_right_with_diag_up_left_hollow: { c: 6, r: 3 },
+  bottom_mass_with_air_ur: { c: 7, r: 3 },
+  bottom_mass_with_air_u: { c: 8, r: 3 },
+  bottom_mass_with_air_ul: { c: 9, r: 3 },
+
+  transparent_a: { c: 1, r: 4 },
+  grass_left_dup: { c: 2, r: 4 },
+  grass_right_dup: { c: 3, r: 4 },
+  transparent_b: { c: 4, r: 4 },
+  platform_to_ground_left: { c: 5, r: 4 },
+  platform_to_ground_right: { c: 6, r: 4 },
+  grass_solo_only_below: { c: 7, r: 4 },
+  ceiling_spikes_top_a: { c: 8, r: 4 },
+  ceiling_spikes_top_b: { c: 9, r: 4 },
+
+  platform_short_left: { c: 1, r: 5 },
+  platform_transition_left_dup: { c: 2, r: 5 },
+  platform_transition_right_dup: { c: 3, r: 5 },
+  platform_short_right: { c: 4, r: 5 },
+  cave_entrance_left: { c: 5, r: 5 },
+  cave_entrance_right: { c: 6, r: 5 },
+  solo_floor_join_lr_down_air: { c: 7, r: 5 },
+  ceiling_spikes_tip_a: { c: 8, r: 5 },
+  ceiling_spikes_tip_b: { c: 9, r: 5 },
+
+  empty_a: { c: 1, r: 6 },
+  bottom_left_dup: { c: 2, r: 6 },
+  bottom_right_dup: { c: 3, r: 6 },
+  empty_b: { c: 4, r: 6 },
+  cave_to_grass_transition_right: { c: 5, r: 6 },
+  cave_to_grass_transition_left: { c: 6, r: 6 },
+  floating_left: { c: 7, r: 6 },
+  floating_mid: { c: 8, r: 6 },
+  floating_right: { c: 9, r: 6 },
+};
+
+// draw tile by logical name
+function drawFloorTile(ctx, name, dx, dy) {
+  const pos = FLOOR_TILES[name];
+  if (!pos) return;
+  const sx = (pos.c - 1) * SRC_TILE;
+  const sy = (pos.r - 1) * SRC_TILE;
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(
+    floorAtlas,
+    sx,
+    sy,
+    SRC_TILE,
+    SRC_TILE,
+    dx,
+    dy,
+    DST_TILE,
+    DST_TILE
+  );
+}
+
+// Autotile logic for basic grass and solid masses
+function autotile(grid, x, y) {
+  const type = grid[y]?.[x];
+  const north = grid[y - 1]?.[x] || 'air';
+  const south = grid[y + 1]?.[x] || 'air';
+  const west = grid[y]?.[x - 1] || 'air';
+  const east = grid[y]?.[x + 1] || 'air';
+
+  if (type === 'grass_top') {
+    if (south === 'solid_mass' || south === 'grass_top') {
+      if (west !== 'grass_top') return 'grass_left';
+      if (east !== 'grass_top') return 'grass_right';
+      return 'grass_mid';
+    } else {
+      if (west !== 'grass_top') return 'grass_overhang_left';
+      if (east !== 'grass_top') return 'grass_overhang_right';
+      return 'grass_overhang_mid';
+    }
+  }
+
+  if (type === 'solid_mass') {
+    const eastSolid = east === 'solid_mass';
+    const westSolid = west === 'solid_mass';
+    const southSolid = south === 'solid_mass';
+    const northSolid = north === 'solid_mass' || north === 'grass_top';
+
+    if (northSolid && !southSolid) {
+      if (!westSolid) return 'bottom_left';
+      if (!eastSolid) return 'bottom_right';
+      return 'bottom_mid';
+    }
+
+    if (northSolid && southSolid && eastSolid && westSolid) {
+      return 'mass_plain';
+    }
+
+    if (!westSolid && southSolid && eastSolid) return 'chasm_end_left';
+    if (!eastSolid && southSolid && westSolid) return 'chasm_end_right';
+  }
+
+  return null;
+}
+
+function drawAutoTiledGrid(ctx, grid) {
+  for (let y = 0; y < grid.length; y++) {
+    for (let x = 0; x < grid[0].length; x++) {
+      const name = autotile(grid, x, y);
+      if (name) drawFloorTile(ctx, name, x * DST_TILE, y * DST_TILE);
+    }
+  }
+}
+
+const LOGICAL_TYPES = ['grass_top', 'solid_mass', 'overhang'];
+
+window.FloorTiles = {
+  SRC_TILE,
+  DST_TILE,
+  SCALE,
+  floorAtlas,
+  FLOOR_TILES,
+  drawFloorTile,
+  autotile,
+  drawAutoTiledGrid,
+  LOGICAL_TYPES,
+};

--- a/js/index.js
+++ b/js/index.js
@@ -67,6 +67,7 @@ const illusions =
     ? l_Illusions
     : collisions.map((row) => row.map(() => 0))
 
+
 function extendLevelRight(layerArrays, extraColumns = LEVEL_EXTENSION_COLUMNS) {
   layerArrays.forEach((layer) => {
     layer.forEach((row) => {
@@ -164,6 +165,14 @@ extendLevelRight([
   deaths,
   illusions,
 ])
+
+const floorGrid = collisions.map((row, y) =>
+  row.map((cell, x) => {
+    if (!cell) return 'air'
+    const north = y > 0 ? collisions[y - 1][x] : 0
+    return north ? 'solid_mass' : 'grass_top'
+  }),
+)
 
 collisions.forEach((row, y) => {
   row.forEach((symbol, x) => {
@@ -307,6 +316,11 @@ const renderStaticLayers = async (layersData) => {
       }
     }
   }
+
+  if (!FloorTiles.floorAtlas.complete) {
+    await new Promise((res) => (FloorTiles.floorAtlas.onload = res))
+  }
+  FloorTiles.drawAutoTiledGrid(offscreenContext, floorGrid)
 
   // Optionally draw collision blocks and platforms for debugging
   // collisionBlocks.forEach(block => block.draw(offscreenContext));


### PR DESCRIPTION
## Summary
- add `floorTiles.js` with 32x32 floor atlas mapping and basic autotile logic
- render floor grid with nearest-neighbor scaling and auto-typing
- build visual floor palette in editor backed by new atlas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac59349d4c832a8dc24e4f34ffb0f9