### PR TITLE
Fix mobile camera scaling

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -10,7 +10,9 @@ function resizeCanvas() {
   canvas.height = innerHeight * dpr
   canvas.style.width = `${innerWidth}px`
   canvas.style.height = `${innerHeight}px`
-  c.setTransform(dpr, 0, 0, dpr, 0, 0)
+  // Reset any existing transforms; scaling for high-DPI displays is handled
+  // within the render loop to avoid applying the device pixel ratio twice.
+  c.setTransform(1, 0, 0, 1, 0, 0)
 }
 
 resizeCanvas()


### PR DESCRIPTION
## Summary
- Reset canvas transform on resize to avoid double application of device pixel ratio

## Testing
- `node --check js/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac60607fd4832a844eac4a8fed3831