### PR TITLE
Improve canvas scaling and mobile camera

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,95 +7,83 @@
     <meta http-equiv="Expires" content="0" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
       rel="stylesheet"
     />
     <style>
-      * {
-        box-sizing: border-box;
-        margin: 0;
-        padding: 0;
-        border: 0;
-        font: inherit;
-        vertical-align: baseline;
-      }
-
       html,
       body {
-        height: 100%;
-        background: black;
-        overflow: hidden;
+        margin: 0;
+        padding: 0;
+        background: #000;
+        overscroll-behavior: none;
         touch-action: none;
+      }
+
+      #game-root {
+        width: 100vw;
+        height: 100svh;
+        position: fixed;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        background: #000;
       }
 
       canvas {
         display: block;
-        width: 100vw;
-        height: 100vh;
+        image-rendering: pixelated;
       }
 
-      /* Touch controls */
-      #joystick-base {
-        position: absolute;
-        bottom: 20px;
-        left: 20px;
-        width: 100px;
-        height: 100px;
-        border-radius: 50%;
-        background: rgba(255, 255, 255, 0.1);
-        touch-action: none;
+      #fs-btn {
+        position: fixed;
+        top: 8px;
+        right: 8px;
+        z-index: 10;
+        background: rgba(0, 0, 0, 0.5);
+        color: #fff;
+        border: none;
+        font-size: 24px;
+        pointer-events: auto;
       }
 
-      #joystick-knob {
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        width: 40px;
-        height: 40px;
-        margin-left: -20px;
-        margin-top: -20px;
-        border-radius: 50%;
-        background: rgba(255, 255, 255, 0.3);
+      #touch-ui {
+        position: fixed;
+        inset: 0;
         pointer-events: none;
-        transition: transform 0.2s ease;
       }
 
-      #attack-button {
+      #dpad {
+        position: absolute;
+        left: 20px;
+        bottom: 20px;
+        width: 96px;
+        height: 96px;
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 8px;
+        pointer-events: auto;
+      }
+
+      #btn-a,
+      #btn-b {
         position: absolute;
         bottom: 20px;
-        right: 20px;
-        width: 60px;
-        height: 60px;
+        width: 72px;
+        height: 72px;
         border-radius: 50%;
         background: rgba(255, 255, 255, 0.3);
-        touch-action: none;
+        pointer-events: auto;
       }
 
-      #jump-button {
-        position: absolute;
-        bottom: 100px;
+      #btn-a {
         right: 20px;
-        width: 60px;
-        height: 60px;
-        border-radius: 50%;
-        background: rgba(255, 255, 255, 0.3);
-        touch-action: none;
       }
 
-      #fullscreen-button {
-        position: absolute;
-        top: 20px;
-        right: 20px;
-        width: 40px;
-        height: 40px;
-        border-radius: 5px;
-        background: rgba(255, 255, 255, 0.3);
-        color: white;
-        font-family: sans-serif;
-        touch-action: none;
+      #btn-b {
+        right: 112px;
       }
 
       #start-screen {
@@ -173,6 +161,12 @@
       #win-screen.hidden {
         display: none;
       }
+
+      @media (pointer: fine) {
+        #touch-ui {
+          display: none;
+        }
+      }
     </style>
   </head>
   <body>
@@ -187,17 +181,15 @@
       </div>
     </div>
     <div id="win-screen" class="hidden">YOU WIN!</div>
-    <canvas style="image-rendering: pixelated"></canvas>
-    <p style="color: white; font-family: sans-serif; margin: 8px">
-      WASD to move, Spacebar to attack. Drag left circle to move and use
-      right buttons on touch devices.
-    </p>
-    <div id="joystick-base">
-      <div id="joystick-knob"></div>
+    <div id="game-root">
+      <canvas id="game"></canvas>
     </div>
-    <div id="attack-button"></div>
-    <div id="jump-button"></div>
-    <button id="fullscreen-button">⛶</button>
+    <button id="fs-btn">⛶</button>
+    <div id="touch-ui">
+      <div id="dpad"></div>
+      <div id="btn-a"></div>
+      <div id="btn-b"></div>
+    </div>
     <script src="./data/l_New_Layer_1.js"></script>
     <script src="./data/l_New_Layer_2.js"></script>
     <script src="./data/l_New_Layer_8.js"></script>
@@ -241,6 +233,8 @@
     <script src="./classes/Sprite.js"></script>
     <script src="./classes/Heart.js"></script>
 
+    <script src="./js/resizeCanvas.js"></script>
+    <script src="./js/camera.js"></script>
     <script src="./js/floorTiles.js"></script>
     <script src="./js/index.js"></script>
     <script src="./js/eventListeners.js"></script>

--- a/js/camera.js
+++ b/js/camera.js
@@ -1,0 +1,41 @@
+const cam = { x: 0, y: 0, zoom: 1 };
+const deadzoneX = 40;
+const deadzoneY = 30;
+const lerp = 0.12;
+const minZoom = 1.0;
+const maxZoom = 1.5;
+
+function updateCamera(player, levelBounds) {
+  const desiredWorldHeight = 11 * TILESIZE_LOGIC;
+  const targetZoom = Math.max(minZoom, Math.min(maxZoom, WORLD_BASE_H / desiredWorldHeight));
+  cam.zoom += (targetZoom - cam.zoom) * 0.08;
+
+  const targetX = player.x + player.width / 2;
+  const targetY = player.y + player.height / 2;
+  const viewW = WORLD_BASE_W / cam.zoom;
+  const viewH = WORLD_BASE_H / cam.zoom;
+  const camCenterX = cam.x + viewW / 2;
+  const camCenterY = cam.y + viewH / 2;
+  const dx = targetX - camCenterX;
+  const dy = targetY - camCenterY;
+  if (Math.abs(dx) > deadzoneX) cam.x += (dx - Math.sign(dx) * deadzoneX) * lerp;
+  if (Math.abs(dy) > deadzoneY) cam.y += (dy - Math.sign(dy) * deadzoneY) * lerp;
+
+  cam.x = Math.max(levelBounds.x, Math.min(cam.x, levelBounds.w - viewW));
+  cam.y = Math.max(levelBounds.y, Math.min(cam.y, levelBounds.h - viewH));
+}
+
+function applyCamera(ctx) {
+  ctx.save();
+  ctx.scale(cam.zoom, cam.zoom);
+  ctx.translate(-Math.floor(cam.x), -Math.floor(cam.y));
+}
+
+function restoreCamera(ctx) {
+  ctx.restore();
+}
+
+window.cam = cam;
+window.updateCamera = updateCamera;
+window.applyCamera = applyCamera;
+window.restoreCamera = restoreCamera;

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -39,69 +39,54 @@ window.addEventListener('focus', () => {
 })
 
 // Touch controls
-const joystickBase = document.getElementById('joystick-base')
-const joystickKnob = document.getElementById('joystick-knob')
-const attackButton = document.getElementById('attack-button')
-const jumpButton = document.getElementById('jump-button')
+const dpad = document.getElementById('dpad')
+const btnA = document.getElementById('btn-a')
+const btnB = document.getElementById('btn-b')
 
-let joystickPointerId = null
+let dpadPointerId = null
 let startX = 0
-let startY = 0
-const JOYSTICK_RADIUS = 50
+const DPAD_THRESHOLD = 20
 
-if (joystickBase && joystickKnob) {
-  joystickBase.addEventListener('pointerdown', (e) => {
-    joystickPointerId = e.pointerId
+if (dpad) {
+  dpad.addEventListener('pointerdown', (e) => {
+    dpadPointerId = e.pointerId
     startX = e.clientX
-    startY = e.clientY
-    joystickKnob.style.transition = '0s'
   })
 
-  joystickBase.addEventListener('pointermove', (e) => {
-    if (e.pointerId !== joystickPointerId) return
-
+  dpad.addEventListener('pointermove', (e) => {
+    if (e.pointerId !== dpadPointerId) return
     const dx = e.clientX - startX
-    const dy = e.clientY - startY
-    const clampedX = Math.max(-JOYSTICK_RADIUS, Math.min(JOYSTICK_RADIUS, dx))
-    const clampedY = Math.max(-JOYSTICK_RADIUS, Math.min(JOYSTICK_RADIUS, dy))
-    joystickKnob.style.transform = `translate(${clampedX}px, ${clampedY}px)`
-
-    const normalizedX = clampedX / JOYSTICK_RADIUS
-
-    keys.a.pressed = normalizedX < -0.3
-    keys.d.pressed = normalizedX > 0.3
+    keys.a.pressed = dx < -DPAD_THRESHOLD
+    keys.d.pressed = dx > DPAD_THRESHOLD
   })
 
-  const endJoystick = () => {
-    joystickPointerId = null
-    joystickKnob.style.transition = '0.2s'
-    joystickKnob.style.transform = 'translate(0px, 0px)'
+  const endDpad = () => {
+    dpadPointerId = null
     keys.a.pressed = false
     keys.d.pressed = false
   }
 
-  joystickBase.addEventListener('pointerup', (e) => {
-    if (e.pointerId === joystickPointerId) endJoystick()
+  dpad.addEventListener('pointerup', (e) => {
+    if (e.pointerId === dpadPointerId) endDpad()
   })
-
-  joystickBase.addEventListener('pointercancel', (e) => {
-    if (e.pointerId === joystickPointerId) endJoystick()
+  dpad.addEventListener('pointercancel', (e) => {
+    if (e.pointerId === dpadPointerId) endDpad()
   })
 }
 
-if (attackButton) {
-  attackButton.addEventListener('pointerdown', () => {
+if (btnB) {
+  btnB.addEventListener('pointerdown', () => {
     player.attack()
   })
 }
 
-if (jumpButton) {
-  jumpButton.addEventListener('pointerdown', () => {
+if (btnA) {
+  btnA.addEventListener('pointerdown', () => {
     player.jump()
   })
 }
 
-const fullscreenButton = document.getElementById('fullscreen-button')
+const fullscreenButton = document.getElementById('fs-btn')
 if (fullscreenButton) {
   const toggleFullscreen = () => {
     const elem = document.documentElement

--- a/js/floorTiles.js
+++ b/js/floorTiles.js
@@ -1,5 +1,6 @@
-const SRC_TILE = 32;
-const DST_TILE = TILE_NATIVE;
+// Source tile size in asset and target logical tile size
+const SRC_TILE = TILESIZE_SRC;
+const DST_TILE = TILESIZE_LOGIC;
 const SCALE = DST_TILE / SRC_TILE;
 
 const floorAtlas = new Image();

--- a/js/index.js
+++ b/js/index.js
@@ -1,22 +1,6 @@
-const canvas = document.querySelector('canvas')
-const c = canvas.getContext('2d')
-c.imageSmoothingEnabled = false
-const dpr = window.devicePixelRatio || 1
+const canvas = window.canvas
+const c = window.ctx
 const winScreen = document.getElementById('win-screen')
-
-function resizeCanvas() {
-  const { innerWidth, innerHeight } = window
-  canvas.width = innerWidth * dpr
-  canvas.height = innerHeight * dpr
-  canvas.style.width = `${innerWidth}px`
-  canvas.style.height = `${innerHeight}px`
-  // Reset any existing transforms; scaling for high-DPI displays is handled
-  // within the render loop to avoid applying the device pixel ratio twice.
-  c.setTransform(1, 0, 0, 1, 0, 0)
-}
-
-resizeCanvas()
-window.addEventListener('resize', resizeCanvas)
 
 const oceanLayerData = {
   l_New_Layer_1: l_New_Layer_1,
@@ -38,24 +22,24 @@ const layersData = {
 }
 
 const tilesets = {
-  l_New_Layer_1: { imageUrl: './images/decorations.png', tileSize: TILE_NATIVE },
-  l_New_Layer_2: { imageUrl: './images/decorations.png', tileSize: TILE_NATIVE },
-  l_New_Layer_8: { imageUrl: './images/tileset.png', tileSize: TILE_NATIVE },
-  l_Back_Tiles: { imageUrl: './images/tileset.png', tileSize: TILE_NATIVE },
-  l_Decorations: { imageUrl: './images/decorations.png', tileSize: TILE_NATIVE },
-  l_Front_Tiles: { imageUrl: './images/tileset.png', tileSize: TILE_NATIVE },
-  l_Shrooms: { imageUrl: './images/decorations.png', tileSize: TILE_NATIVE },
-  l_Collisions: { imageUrl: './images/tileset.png', tileSize: TILE_NATIVE },
-  l_Grass: { imageUrl: './images/tileset.png', tileSize: TILE_NATIVE },
-  l_Trees: { imageUrl: './images/decorations.png', tileSize: TILE_NATIVE },
+  l_New_Layer_1: { imageUrl: './images/decorations.png', tileSize: TILESIZE_SRC },
+  l_New_Layer_2: { imageUrl: './images/decorations.png', tileSize: TILESIZE_SRC },
+  l_New_Layer_8: { imageUrl: './images/tileset.png', tileSize: TILESIZE_SRC },
+  l_Back_Tiles: { imageUrl: './images/tileset.png', tileSize: TILESIZE_SRC },
+  l_Decorations: { imageUrl: './images/decorations.png', tileSize: TILESIZE_SRC },
+  l_Front_Tiles: { imageUrl: './images/tileset.png', tileSize: TILESIZE_SRC },
+  l_Shrooms: { imageUrl: './images/decorations.png', tileSize: TILESIZE_SRC },
+  l_Collisions: { imageUrl: './images/tileset.png', tileSize: TILESIZE_SRC },
+  l_Grass: { imageUrl: './images/tileset.png', tileSize: TILESIZE_SRC },
+  l_Trees: { imageUrl: './images/decorations.png', tileSize: TILESIZE_SRC },
 }
 
 // Determine on-screen tile and figure sizes
-let tile_on_screen_px = TILE_NATIVE
+let tile_on_screen_px = TILESIZE_LOGIC
 const figure_on_screen_px = clamp(
-  Math.round((FIGURE_NATIVE / TILE_NATIVE) * tile_on_screen_px),
-  Math.round((FIGURE_NATIVE - 1) * tile_on_screen_px / TILE_NATIVE),
-  Math.round((FIGURE_NATIVE + 1) * tile_on_screen_px / TILE_NATIVE),
+  Math.round((FIGURE_NATIVE / TILESIZE_SRC) * TILESIZE_LOGIC),
+  Math.round(((FIGURE_NATIVE - 1) * TILESIZE_LOGIC) / TILESIZE_SRC),
+  Math.round(((FIGURE_NATIVE + 1) * TILESIZE_LOGIC) / TILESIZE_SRC),
 )
 const player_scale = figure_on_screen_px / FIGURE_NATIVE
 const LEVEL_EXTENSION_COLUMNS = 20
@@ -192,7 +176,14 @@ collisions.forEach((row, y) => {
 
 const l_Filler = createFillerLayer(collisions)
 layersData.l_Filler = l_Filler
-tilesets.l_Filler = { imageUrl: './images/filler.png', tileSize: TILE_NATIVE }
+tilesets.l_Filler = { imageUrl: './images/filler.png', tileSize: TILESIZE_SRC }
+
+const levelBounds = {
+  x: 0,
+  y: 0,
+  w: collisions[0].length * TILESIZE_LOGIC,
+  h: collisions.length * TILESIZE_LOGIC,
+}
 
 const LEVEL_EXTENSION_OFFSET = LEVEL_EXTENSION_COLUMNS * tile_on_screen_px
 
@@ -404,10 +395,7 @@ const keys = {
 }
 
 let lastTime = performance.now()
-let camera = {
-  x: 0,
-  y: 0,
-}
+let camera = cam
 
 let oceanBackgroundCanvas = null
 let brambleBackgroundCanvas = null
@@ -581,10 +569,8 @@ function init() {
     }),
   ]
 
-  camera = {
-    x: 0,
-    y: 0,
-  }
+  camera.x = 0
+  camera.y = 0
 }
 
 function animate(backgroundCanvas) {
@@ -773,30 +759,14 @@ function animate(backgroundCanvas) {
     }
   }
 
-  // Center camera on player and clamp to level bounds
-  const viewportWidth = canvas.width / dpr
-  const viewportHeight = canvas.height / dpr
-  const levelWidth = collisions[0].length * tile_on_screen_px
-  const levelHeight = collisions.length * tile_on_screen_px
-
-  camera.x = player.x - viewportWidth / 2
-  camera.y = player.y - viewportHeight / 2
-
-  const maxCamX = levelWidth - viewportWidth
-  const maxCamY = levelHeight - viewportHeight
-
-  camera.x =
-    maxCamX < 0 ? maxCamX / 2 : Math.max(0, Math.min(camera.x, maxCamX))
-  camera.y =
-    maxCamY < 0 ? maxCamY / 2 : Math.max(0, Math.min(camera.y, maxCamY))
+  // Update and apply camera
+  updateCamera(player, levelBounds)
 
   // Render scene
   c.save()
   c.clearRect(0, 0, canvas.width, canvas.height)
-  c.scale(dpr, dpr)
+  applyCamera(c)
   const camX = Math.round(camera.x)
-  const camY = Math.round(camera.y)
-  c.translate(-camX, -camY)
   c.drawImage(oceanBackgroundCanvas, Math.round(camX * 0.32), 0)
   c.drawImage(brambleBackgroundCanvas, Math.round(camX * 0.16), 0)
   c.drawImage(backgroundCanvas, 0, 0)
@@ -822,11 +792,10 @@ function animate(backgroundCanvas) {
     gem.draw(c)
   }
 
-  c.restore()
+  restoreCamera(c)
 
-  // UI save and restore
+  // UI
   c.save()
-  c.scale(dpr, dpr)
   for (let i = hearts.length - 1; i >= 0; i--) {
     const heart = hearts[i]
     heart.draw(c)

--- a/js/resizeCanvas.js
+++ b/js/resizeCanvas.js
@@ -1,0 +1,27 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d', { alpha: false });
+ctx.imageSmoothingEnabled = false;
+if (ctx.webkitImageSmoothingEnabled !== undefined) ctx.webkitImageSmoothingEnabled = false;
+if (ctx.mozImageSmoothingEnabled !== undefined) ctx.mozImageSmoothingEnabled = false;
+
+function fitCanvasToScreen() {
+  const cssW = window.innerWidth;
+  const cssH = window.innerHeight;
+  const intScale = Math.max(1, Math.floor(Math.min(cssW / WORLD_BASE_W, cssH / WORLD_BASE_H)));
+  const viewW = WORLD_BASE_W * intScale;
+  const viewH = WORLD_BASE_H * intScale;
+  canvas.style.width = viewW + 'px';
+  canvas.style.height = viewH + 'px';
+  const dpr = Math.max(1, Math.floor(window.devicePixelRatio || 1));
+  canvas.width = Math.round(viewW * dpr);
+  canvas.height = Math.round(viewH * dpr);
+  ctx.setTransform(intScale * dpr, 0, 0, intScale * dpr, 0, 0);
+}
+
+window.addEventListener('resize', fitCanvasToScreen);
+window.addEventListener('orientationchange', () => setTimeout(fitCanvasToScreen, 250));
+document.addEventListener('DOMContentLoaded', fitCanvasToScreen);
+
+window.canvas = canvas;
+window.ctx = ctx;
+window.fitCanvasToScreen = fitCanvasToScreen;

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,7 +1,16 @@
 // Global sizing constants
-const TILE_NATIVE = 16
+// Logical world size (16:9 retro base)
+const WORLD_BASE_W = 320
+const WORLD_BASE_H = 180
+// Tile sizes
+const TILESIZE_LOGIC = 16
+const TILESIZE_SRC = 32
+// Preserve old constant name for backwards compatibility
+const TILE_NATIVE = TILESIZE_LOGIC
+// Sprite frame dimensions
 const FRAME_WIDTH = 80
 const FRAME_HEIGHT = 64
+// Player asset height
 const FIGURE_NATIVE = 46
 
 const clamp = (val, min, max) => Math.min(Math.max(val, min), max)


### PR DESCRIPTION
## Summary
- Refactor index layout for responsive fullscreen canvas with touch controls
- Add resize helper and camera system for smooth follow and zoom
- Use 32px source tiles rendered as 16px logic tiles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac670c8258832ab24bc6691bbbeee6