### PR TITLE
feat: add multi-tile floor graphics

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -68,6 +68,28 @@ const defaultState = JSON.parse(
 let floorImg;
 const enemyImgs = {};
 let gemImg;
+const FLOOR_TILE_SIZE = 32;
+
+function getFloorSrc(x, y) {
+  const hasLeft = x > 0 && floors[y][x - 1];
+  const hasRight = x < gridWidth - 1 && floors[y][x + 1];
+  const hasAbove = y > 0 && floors[y - 1][x];
+  const hasBelow = y < gridHeight - 1 && floors[y + 1][x];
+
+  if (!hasAbove) {
+    if (!hasLeft) return [0, 0];
+    if (!hasRight) return [FLOOR_TILE_SIZE * 2, 0];
+    return [FLOOR_TILE_SIZE, 0];
+  } else if (!hasBelow) {
+    if (!hasLeft) return [0, FLOOR_TILE_SIZE * 2];
+    if (!hasRight) return [FLOOR_TILE_SIZE * 2, FLOOR_TILE_SIZE * 2];
+    return [FLOOR_TILE_SIZE, FLOOR_TILE_SIZE * 2];
+  } else {
+    if (!hasLeft) return [0, FLOOR_TILE_SIZE];
+    if (!hasRight) return [FLOOR_TILE_SIZE * 2, FLOOR_TILE_SIZE];
+    return [FLOOR_TILE_SIZE, FLOOR_TILE_SIZE];
+  }
+}
 
 function loadImage(src) {
   return new Promise((resolve, reject) => {
@@ -79,7 +101,7 @@ function loadImage(src) {
 }
 
 Promise.all([
-  loadImage('./images/tileset.png'),
+  loadImage('./images/floor.png'),
   loadImage('./images/oposum.png'),
   loadImage('./images/eagle.png'),
   loadImage('./images/gem.png'),
@@ -112,12 +134,13 @@ function drawGrid() {
   for (let y = 0; y < gridHeight; y++) {
     for (let x = 0; x < gridWidth; x++) {
       if (floors[y][x]) {
+        const [sx, sy] = getFloorSrc(x, y);
         ctx.drawImage(
           floorImg,
-          0,
-          0,
-          16,
-          16,
+          sx,
+          sy,
+          FLOOR_TILE_SIZE,
+          FLOOR_TILE_SIZE,
           x * tileSize,
           y * tileSize,
           tileSize,

--- a/js/index.js
+++ b/js/index.js
@@ -39,7 +39,7 @@ const tilesets = {
   l_Decorations: { imageUrl: './images/decorations.png', tileSize: TILE_NATIVE },
   l_Front_Tiles: { imageUrl: './images/tileset.png', tileSize: TILE_NATIVE },
   l_Shrooms: { imageUrl: './images/decorations.png', tileSize: TILE_NATIVE },
-  l_Collisions: { imageUrl: './images/tileset.png', tileSize: TILE_NATIVE },
+  l_Collisions: { imageUrl: './images/floor.png', tileSize: 32 },
   l_Grass: { imageUrl: './images/tileset.png', tileSize: TILE_NATIVE },
   l_Trees: { imageUrl: './images/decorations.png', tileSize: TILE_NATIVE },
 }
@@ -146,6 +146,28 @@ function createFillerLayer(collisions) {
   return filler
 }
 
+function getFloorTileIndex(grid, x, y) {
+  if (grid[y][x] !== 1) return 0
+  const hasLeft = x > 0 && grid[y][x - 1] === 1
+  const hasRight = x < grid[0].length - 1 && grid[y][x + 1] === 1
+  const hasAbove = y > 0 && grid[y - 1][x] === 1
+  const hasBelow = y < grid.length - 1 && grid[y + 1][x] === 1
+
+  if (!hasAbove) {
+    if (!hasLeft) return 1
+    if (!hasRight) return 3
+    return 2
+  } else if (!hasBelow) {
+    if (!hasLeft) return 7
+    if (!hasRight) return 9
+    return 8
+  } else {
+    if (!hasLeft) return 4
+    if (!hasRight) return 6
+    return 5
+  }
+}
+
 extendLevelRight([
   collisions,
   l_New_Layer_1,
@@ -167,7 +189,7 @@ extendLevelRight([
 
 collisions.forEach((row, y) => {
   row.forEach((symbol, x) => {
-    l_Collisions[y][x] = symbol === 1 ? 1 : 0
+    l_Collisions[y][x] = getFloorTileIndex(collisions, x, y)
     if (symbol === 0) {
       if (l_Back_Tiles[y]) l_Back_Tiles[y][x] = 0
       if (l_Front_Tiles[y]) l_Front_Tiles[y][x] = 0


### PR DESCRIPTION
## Summary
- render multi-tile floors from new 3x3 `floor.png`
- choose floor tile variant based on neighboring blocks for runtime and editor

## Testing
- `node --check js/index.js`
- `node --check js/editor.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac7613da48832a8ec914e8afb93707