### PR TITLE
Persist level data outside repository

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -49,24 +49,7 @@
   <textarea id="output" placeholder="Saved level data will appear here"></textarea>
   <script>
     const cb = Date.now();
-    document.write(
-      '<script src="./data/collisions.js?cb=' + cb + '"></' + 'script>'
-    );
-    document.write(
-      '<script src="./data/l_Gems.js?cb=' + cb + '"></' + 'script>'
-    );
-    document.write(
-      '<script src="./data/l_Enemies.js?cb=' + cb + '"></' + 'script>'
-    );
-    document.write(
-      '<script src="./data/l_Blockers.js?cb=' + cb + '"></' + 'script>'
-    );
-    document.write(
-      '<script src="./data/l_Deaths.js?cb=' + cb + '"></' + 'script>'
-    );
-    document.write(
-      '<script src="./data/l_Illusions.js?cb=' + cb + '"></' + 'script>'
-    );
+    document.write('<script src="level.php?cb=' + cb + '"></' + 'script>');
   </script>
   <script src="js/editor.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -208,24 +208,7 @@
     <script src="./data/l_Trees.js"></script>
     <script>
       const cb = Date.now();
-      document.write(
-        '<script src="./data/l_Blockers.js?cb=' + cb + '"></' + 'script>'
-      );
-      document.write(
-        '<script src="./data/l_Deaths.js?cb=' + cb + '"></' + 'script>'
-      );
-      document.write(
-        '<script src="./data/l_Illusions.js?cb=' + cb + '"></' + 'script>'
-      );
-      document.write(
-        '<script src="./data/l_Gems.js?cb=' + cb + '"></' + 'script>'
-      );
-      document.write(
-        '<script src="./data/l_Enemies.js?cb=' + cb + '"></' + 'script>'
-      );
-      document.write(
-        '<script src="./data/collisions.js?cb=' + cb + '"></' + 'script>'
-      );
+      document.write('<script src="level.php?cb=' + cb + '"></' + 'script>');
     </script>
     <script src="./js/utils.js"></script>
     <script src="./classes/CollisionBlock.js"></script>

--- a/level.php
+++ b/level.php
@@ -1,0 +1,27 @@
+<?php
+header('Content-Type: application/javascript');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Pragma: no-cache');
+
+$levelPath = __DIR__ . '/../level/level.json';
+if (file_exists($levelPath)) {
+    $json = json_decode(file_get_contents($levelPath), true);
+    if ($json) {
+        echo 'const collisions = ' . json_encode($json['collisions']) . ';';
+        echo 'const l_Gems = ' . json_encode($json['gems']) . ';';
+        echo 'const l_Enemies = ' . json_encode($json['enemies']) . ';';
+        echo 'const l_Blockers = ' . json_encode($json['blockers']) . ';';
+        echo 'const l_Deaths = ' . json_encode($json['deaths']) . ';';
+        echo 'const l_Illusions = ' . json_encode($json['illusions']) . ';';
+        exit;
+    }
+}
+
+$base = __DIR__ . '/data/';
+readfile($base . 'collisions.js');
+readfile($base . 'l_Gems.js');
+readfile($base . 'l_Enemies.js');
+readfile($base . 'l_Blockers.js');
+readfile($base . 'l_Deaths.js');
+readfile($base . 'l_Illusions.js');
+?>

--- a/save.php
+++ b/save.php
@@ -14,19 +14,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         isset($data['deaths']) &&
         isset($data['illusions'])
     ) {
-        $collisions = 'const collisions = ' . json_encode($data['collisions']) . ';';
-        $gems = 'const l_Gems = ' . json_encode($data['gems']) . ';';
-        $enemies = 'const l_Enemies = ' . json_encode($data['enemies']) . ';';
-        $blockers = 'const l_Blockers = ' . json_encode($data['blockers']) . ';';
-        $deaths = 'const l_Deaths = ' . json_encode($data['deaths']) . ';';
-        $illusions = 'const l_Illusions = ' . json_encode($data['illusions']) . ';';
-        file_put_contents(__DIR__ . '/data/collisions.js', $collisions);
-        file_put_contents(__DIR__ . '/data/l_Gems.js', $gems);
-        file_put_contents(__DIR__ . '/data/l_Enemies.js', $enemies);
-        file_put_contents(__DIR__ . '/data/l_Blockers.js', $blockers);
-        file_put_contents(__DIR__ . '/data/l_Deaths.js', $deaths);
-        file_put_contents(__DIR__ . '/data/l_Illusions.js', $illusions);
-        echo 'Saved';
+        $levelDir = __DIR__ . '/../level';
+        if (!is_dir($levelDir)) {
+            mkdir($levelDir, 0755, true);
+        }
+        $saved = file_put_contents(
+            $levelDir . '/level.json',
+            json_encode($data)
+        );
+        if ($saved === false) {
+            http_response_code(500);
+            echo 'Save failed';
+        } else {
+            echo 'Saved';
+        }
     } else {
         http_response_code(400);
         echo 'Invalid data';


### PR DESCRIPTION
## Summary
- Store level data in a persistent `level/level.json` outside the repository when saving
- Serve saved level data through new `level.php`, falling back to repo defaults
- Load persistent level data in editor and game by including `level.php`

## Testing
- `php -l save.php`
- `php -l level.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac9c225354832abf3b113c0e5e1c69