### PR TITLE
Enable touch scrolling in level editor and improve mobile buttons

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -25,6 +25,15 @@
       padding: 8px 12px;
       font-size: 16px;
     }
+    @media (max-width: 600px) {
+      #toolbar {
+        flex-wrap: wrap;
+      }
+      #toolbar button {
+        padding: 12px 16px;
+        font-size: 20px;
+      }
+    }
     canvas { background: #333; image-rendering: pixelated; }
     #output { width: 100%; height: 100px; margin-top: 8px; }
     #save-status { margin-top: 8px; font-weight: bold; }

--- a/js/editor.js
+++ b/js/editor.js
@@ -202,13 +202,19 @@ window.addEventListener('mouseup', () => {
 });
 
 canvas.addEventListener('touchstart', (e) => {
-  e.preventDefault();
-  drawing = true;
-  handle(e);
+  if (e.touches.length === 1) {
+    e.preventDefault();
+    drawing = true;
+    handle(e);
+  } else {
+    drawing = false;
+  }
 });
 canvas.addEventListener('touchmove', (e) => {
-  e.preventDefault();
-  if (drawing) handle(e);
+  if (drawing && e.touches.length === 1) {
+    e.preventDefault();
+    handle(e);
+  }
 });
 window.addEventListener('touchend', () => {
   drawing = false;


### PR DESCRIPTION
## Summary
- Allow two-finger touch scrolling in the level editor without blocking painting
- Increase toolbar button size on small screens for better mobile usability

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ac9d8491f4832a95826f50205b6c83